### PR TITLE
Use new Notification class with fallback to mozNotification

### DIFF
--- a/app/scripts/utils/notifications.js
+++ b/app/scripts/utils/notifications.js
@@ -103,14 +103,15 @@ define([
     _createNotification: function (title, body) {
       var _this = this;
       var icon = _this._getIconURI(_this._app);
+      var notification;
 
       if ('Notification' in window) {
-        var notification =
+        notification =
           new window.Notification(title, {'body': body, 'icon': icon});
       }
       else {
         // support legacy notifications prior to Firefox 22 (Firefox OS <1.2)
-        var notification =
+        notification =
           navigator.mozNotification.createNotification(title, body, icon);
       }
 
@@ -136,7 +137,9 @@ define([
       _this._unattendedNotifications++;
 
       // support legacy notifications prior to Firefox 22 (Firefox OS <1.2)
-      notification.show && notification.show();
+      if (notification.show) {
+        notification.show();
+      }
     },
 
     /**

--- a/app/scripts/utils/notifications.js
+++ b/app/scripts/utils/notifications.js
@@ -104,8 +104,15 @@ define([
       var _this = this;
       var icon = _this._getIconURI(_this._app);
 
-      var notification =
-        navigator.mozNotification.createNotification(title, body, icon);
+      if ('Notification' in window) {
+        var notification =
+          new window.Notification(title, {'body': body, 'icon': icon});
+      }
+      else {
+        // support legacy notifications prior to Firefox 22 (Firefox OS <1.2)
+        var notification =
+          navigator.mozNotification.createNotification(title, body, icon);
+      }
 
       notification.onclick = function () {
         _this._app.launch();
@@ -124,7 +131,9 @@ define([
       };
 
       _this._unattendedNotifications++;
-      notification.show();
+
+      // support legacy notifications prior to Firefox 22 (Firefox OS <1.2)
+      notification.show && notification.show();
     },
 
     /**

--- a/app/scripts/utils/notifications.js
+++ b/app/scripts/utils/notifications.js
@@ -124,6 +124,9 @@ define([
         if (platform.isFFOS11()) {
           _this._unattendedNotifications--;
         }
+
+        // close the notification after user is directed to the chat
+        notification.close();
       };
 
       notification.onclose = function () {


### PR DESCRIPTION
As mentioned in #11 by @ccarruitero there is a new `Notification` API in Firefox >= 22 (Firefox OS >=1.2). This PR makes use of it, with fallback to the legacy `navigator.mozNotification`.