### PR TITLE
Close or remove Notification if User clicks on it

### DIFF
--- a/app/scripts/utils/notifications.js
+++ b/app/scripts/utils/notifications.js
@@ -117,6 +117,9 @@ define([
         if (platform.isFFOS11()) {
           _this._unattendedNotifications--;
         }
+
+        // close the notification after user is directed to the chat
+        notification.close();
       };
 
       notification.onclose = function () {


### PR DESCRIPTION
In the current 1.7.x branch the notifications for new messages keep in the list, even if the user clicks on it and is redirected to the chat.

This small PR will remove a notification after the user has clicked on it, similar to the behaviour of notifications for normal SMS.