### PR TITLE
Update min and max length of screen name and status message

### DIFF
--- a/app/scripts/templates/profile.hbs
+++ b/app/scripts/templates/profile.hbs
@@ -29,14 +29,14 @@
         <p>
           <input type="text"
           name="screen-name" placeholder="{{translate 'screenNamePlaceHolder'}}"
-          maxlength="30" required value="{{screenName}}"
+          maxlength="25" required value="{{screenName}}"
           id="input-screen-name">
           </input>
         </p>
         <p>{{translate 'screenNameDescription'}}</p>
         <p>
           <input type="text"
-          name="status" placeholder="{{translate 'statusPlaceHolder'}}" required
+          name="status" placeholder="{{translate 'statusPlaceHolder'}}" maxlength="139" required
           value="{{status}}" id="input-status">
           </input>
         </p>

--- a/app/scripts/views/profile.js
+++ b/app/scripts/views/profile.js
@@ -59,8 +59,9 @@ define([
     checkNameInput: function (evt) {
       if (evt) { evt.preventDefault(); }
       var name = $('input[name=screen-name]').val();
+      name = name.trim();
       var button = $('button.done');
-      button.prop('disabled', name.length < 3);
+      button.prop('disabled', name.length === 0);
     },
 
     updateProfileDataFromServer: function () {


### PR DESCRIPTION
Checked the screen name and the status length in WhatsApp Messenger v2.12.82

The screen name is allowed to be 1 character and maximum 25 characters, but is should not be empty (not only contain whitespaces). In WhatsApp Messenger one character also equals one smiley image.

1 <= screenName.length <= 25

The maximum length for the status is 139 characters.

TODO: The status should not be empty, too (there is no check for that at the moment)

1 <= statusMessage.length <= 139