### PR TITLE
Allow to send messages with enter key

### DIFF
--- a/app/locales/openwapp.en-US.properties
+++ b/app/locales/openwapp.en-US.properties
@@ -156,3 +156,4 @@ chooseNetwork = Please choose your carrier below
 sameNumberMultiplePhonesWarning = Simultaneous usage of the same mobile number on different devices can lead to unexpected errors.
 carrier = Carrier
 simCard = SIM-Card
+sendByEnter = Send by enter key

--- a/app/scripts/templates/profile.hbs
+++ b/app/scripts/templates/profile.hbs
@@ -49,7 +49,7 @@
         <p>{{translate 'wakeUpDescription'}}</p>
         <p>
           <input type="checkbox" id="send-by-enter" />
-          <label for="send-by-enter">Send by enter key</label>
+          <label for="send-by-enter">{{translate 'sendByEnter'}}</label>
         </p>
       </form>
       <hr />

--- a/app/scripts/templates/profile.hbs
+++ b/app/scripts/templates/profile.hbs
@@ -47,6 +47,10 @@
           </fieldset>
         </p>
         <p>{{translate 'wakeUpDescription'}}</p>
+        <p>
+          <input type="checkbox" id="send-by-enter" />
+          <label for="send-by-enter">Send by enter key</label>
+        </p>
       </form>
       <hr />
       <p>{{translate 'accountExpiration'}}: {{formattedMessageDate expiration}}</p>

--- a/app/scripts/views/compose-message.js
+++ b/app/scripts/views/compose-message.js
@@ -17,7 +17,8 @@ define([
     events: {
       'click #conversation-send-button' : '_createTextMessage',
       'click #insert-emoji': '_toggleEmojiList',
-      'click #message-text-input': '_hideEmojiList'
+      'click #message-text-input': '_hideEmojiList',
+      'keydown #message-text-input' : '_sendByEnter'
     },
 
     initialize: function () {
@@ -94,6 +95,13 @@ define([
         return d.textContent;
       });
       return lines.join('\n');
+    },
+    
+    _sendByEnter: function (e) {
+      if(e.key === 'Enter' && localStorage.getItem('sendByEnter')) {
+        this.el.querySelector('#conversation-send-button').click(); // Send the message
+        e.preventDefault(); // Don't write a newline in the message box
+      }
     }
   });
 });

--- a/app/scripts/views/compose-message.js
+++ b/app/scripts/views/compose-message.js
@@ -17,8 +17,7 @@ define([
     events: {
       'click #conversation-send-button' : '_createTextMessage',
       'click #insert-emoji': '_toggleEmojiList',
-      'click #message-text-input': '_hideEmojiList',
-      'keydown #message-text-input' : '_sendByEnter'
+      'click #message-text-input': '_hideEmojiList'
     },
 
     initialize: function () {
@@ -50,6 +49,16 @@ define([
       });
       $('#conversation').after(this._emojiSelector.render().el);
       this._emojiSelector.changeTab('people');
+      
+      if(localStorage.getItem('sendByEnter')) {
+        var btn = this.el.querySelector('#conversation-send-button');
+        this.el.querySelector('#message-text-input').addEventListener('keydown', function (e) {
+          if(e.key === 'Enter') {
+            btn.click(); // Send the message
+            e.preventDefault(); // Don't write a newline in the message box
+          }
+        });
+      }
     },
 
     _createTextMessage: function (event) {
@@ -95,13 +104,6 @@ define([
         return d.textContent;
       });
       return lines.join('\n');
-    },
-    
-    _sendByEnter: function (e) {
-      if(e.key === 'Enter' && localStorage.getItem('sendByEnter')) {
-        this.el.querySelector('#conversation-send-button').click(); // Send the message
-        e.preventDefault(); // Don't write a newline in the message box
-      }
     }
   });
 });

--- a/app/scripts/views/profile.js
+++ b/app/scripts/views/profile.js
@@ -44,6 +44,8 @@ define([
       awakePeriod = (awakePeriod / 60000).toFixed(0);
       var selected = 'option[value="' + awakePeriod  + '"]';
       this.el.querySelector(selected).setAttribute('selected', 'selected');
+      
+      this.el.querySelector('#send-by-enter').checked = !!localStorage.getItem('sendByEnter');
     },
 
     events: {
@@ -53,7 +55,8 @@ define([
       'click img':                           'selectPicture',
       'click legend':                        'showSelect',
       'change select':                       'setAwakePeriod',
-      'click #upgrade-now':                  'goToUpgradeNow'
+      'click #upgrade-now':                  'goToUpgradeNow',
+      'change #send-by-enter':               'setSendByEnter'
     },
 
     checkNameInput: function (evt) {
@@ -190,6 +193,14 @@ define([
 
     clear: function () {
       window.URL.revokeObjectURL(this.$el.find('img').attr('src'));
+    },
+    
+    setSendByEnter: function (evt) {
+      if(evt.target.checked) {
+        localStorage.setItem('sendByEnter', '1');
+      } else {
+        localStorage.removeItem('sendByEnter');
+      }
     }
   });
 


### PR DESCRIPTION
Add a preference to allow to send messages just by pressing the enter key, without having to click the send button.

This fixes #161.

I guess the label next to the checkbox needs to be translated, though.