### PR TITLE
Fixed wrong access to language service

### DIFF
--- a/app/scripts/views/login.js
+++ b/app/scripts/views/login.js
@@ -19,9 +19,11 @@ define([
   'zeptojs',
   'global',
   'templates',
+  'utils/language',
   'utils/phonenumber',
   'collections/countries'
-], function (Backbone, $, global, templates, PhoneNumber, CountriesCollection) {
+], function (Backbone, $, global, templates, Language, PhoneNumber,
+             CountriesCollection) {
   'use strict';
 
   var localStorage = window.localStorage;
@@ -368,7 +370,7 @@ define([
       this.$el.find('section.intro > p').hide();
       this.toggleSpinner();
 
-      var locale = global.language.getLocale();
+      var locale = Language.getLocale();
       var phoneParts = this._getPhoneParts('#confirm-phone-page');
       var countryCode = phoneParts.prefix;
       var phoneNumber = phoneParts.number;


### PR DESCRIPTION
Calling `global.language.getLocale()` in *login.js* view was wrong in my PR #180.
I have confused it with the language service. This PR addresses this problem.