### PR TITLE
Fixed group icon size for messages with line breaks.

### DIFF
--- a/app/styles/_inbox.sass
+++ b/app/styles/_inbox.sass
@@ -25,7 +25,7 @@
     display: inline-block
     width: 1.4rem
     height: 1.4rem
-    background: url(/images/icon_14px_#{$name}_unread2x.png) 0 0 no-repeat
+    background: url(/images/icon_14px_#{$name}_unread2x.png) 0 0.1rem no-repeat
     +background-size(1.4rem 1.4rem)
     margin-right: 0.5rem
   &.read:before
@@ -50,9 +50,9 @@
     &.group dd.event
       background-repeat: no-repeat
       background-image: url(/images/shared/headers/images/icons/group.png)
-      background-position: center left
-      background-size: auto 100%
-      padding-left: 3rem
+      background-position: 0 0.35rem
+      background-size: 1.7rem 1.7rem
+      padding-left: 2.2rem
   aside
     vertical-align: middle
     display: inline-block


### PR DESCRIPTION
When the last message of a group chat consists of more than one line, the group-icon next to the message preview was transformed vertically to 100% height (of the `<dd>` element), because of background-size 100%.

Additionally I have aligned the message icon to the text.