### PR TITLE
Showing and sorting by sent date instead of received date (fixes #72)

### DIFF
--- a/app/scripts/collections/messages.js
+++ b/app/scripts/collections/messages.js
@@ -31,12 +31,16 @@ define([
     },
 
     /**
-     * Order the coollection by date
+     * Order the collection by date
      * @param  two models to compare A B
      * @return -1 if A before B, 0 if equal, 1 if after.
      */
     comparator: function (message) {
       var meta = message.get('meta');
+      if (meta && meta.sentDate) {
+        return meta.sentDate;
+      }
+      // fallback for legacy code
       return meta && meta.date ? meta.date : -1;
     },
 

--- a/app/scripts/collections/messages.js
+++ b/app/scripts/collections/messages.js
@@ -37,11 +37,12 @@ define([
      */
     comparator: function (message) {
       var meta = message.get('meta');
-      if (meta && meta.sentDate) {
-        return meta.sentDate;
+      var rv = -1;
+      if (meta) {
+        rv = meta.sentDate || meta.date;
       }
-      // fallback for legacy code
-      return meta && meta.date ? meta.date : -1;
+
+      return rv;
     },
 
     add: function (models, options) {

--- a/app/scripts/models/message.js
+++ b/app/scripts/models/message.js
@@ -11,7 +11,7 @@ define([
     defaults: function () {
       return {
         type: 'text',
-        meta: {},    // date, commId
+        meta: {},    // date, sentDate, commId
         contents: '',
         from: {},  // msisdn
         conversationId: null,
@@ -37,8 +37,9 @@ define([
       }
       obj.type = this.get('type');
       obj.metaType = this.get('meta').type;
-      obj.date = this.get('meta') ? this.get('meta').date : new Date();
-      obj.date = obj.date ? obj.date : new Date();
+      obj.date = this.get('meta').date ? this.get('meta').date : new Date();
+      obj.sentDate = this.get('meta').sentDate ?
+        this.get('meta').sentDate : new Date();
       obj.commId = this.get('meta') ? this.get('meta').commId : undefined;
       obj.contents = this.get('contents');
       if (this.get('from') && this.get('from').authorMsisdn) {
@@ -110,8 +111,13 @@ define([
     newFromStorage: function (readJson) {
       var obj = {};
       obj.type = readJson.type;
-      obj.meta = { date : readJson.date, commId : readJson.commId,
-                   type: readJson.metaType };
+      obj.meta = {
+        date: readJson.date,
+        // fallback to date to support old versions
+        sentDate: readJson.sentDate || readJson.date,
+        commId: readJson.commId,
+        type: readJson.metaType
+      };
       obj.from = { msisdn : readJson.msisdn,
                    displayName : readJson.displayName,
                    authorMsisdn: readJson.authorMsisdn || undefined };

--- a/app/scripts/models/rtc.js
+++ b/app/scripts/models/rtc.js
@@ -54,7 +54,7 @@
 //
 // **message** (from, meta, message): when receiving any type of message.
 // Format of from and meta params:
-//     { from: { msisdn, displayName }, meta: { type, date, commId} }
+//     { from: { msisdn, displayName }, meta: { type, date, sentDate, commId} }
 //
 // **message:text (from, meta, message)**: text message received.
 //
@@ -299,6 +299,7 @@ define([
     _getMessageMeta: function (message) {
       return {
         date: new Date(),
+        sentDate: message.sentDate,
         commId: message.messageId
       };
     },

--- a/app/scripts/templates/location-message.hbs
+++ b/app/scripts/templates/location-message.hbs
@@ -6,7 +6,7 @@
     {{locationText}}
   </span>
 
-  <time>{{formattedMessageDate meta.date}}</time>
+  <time>{{formattedMessageDate meta.sentDate}}</time>
   {{#ifIsUnsent status }}
     <button class="resend"><span>↻</span></button>
   {{/ifIsUnsent}}

--- a/app/scripts/templates/multimedia-message.hbs
+++ b/app/scripts/templates/multimedia-message.hbs
@@ -10,7 +10,7 @@
       <img class="" src="{{contents.thumbSrc}}">
     </a>
   </aside>
-  <time>{{formattedMessageDate meta.date}}</time>
+  <time>{{formattedMessageDate meta.sentDate}}</time>
   {{#ifIsUnsent status }}
     {{! not traslated because it will be replaced with a picture }}
     <button class="resend"><span>Resend</span></button>

--- a/app/scripts/templates/text-message.hbs
+++ b/app/scripts/templates/text-message.hbs
@@ -1,7 +1,7 @@
 <li class="{{messageOwnerClass from.msisdn}} text {{status}}" data-message-id={{_id}} data-timestamp="{{meta.timestamp}}">
   <span class="author">{{author}}</span>
   <span class="content">{{expand contents}}</span>
-  <time>{{formattedMessageDate meta.date}}</time>
+  <time>{{formattedMessageDate meta.sentDate}}</time>
   {{#ifIsUnsent status }}
     {{! not traslated because it will be replaced with a picture }}
     <button class="resend"><span>Resend</span></button>

--- a/app/scripts/vendor/coseme-client/client.js
+++ b/app/scripts/vendor/coseme-client/client.js
@@ -241,33 +241,49 @@
 
       function onSubjectUpdated(senderJID, timestamp, messageId,
                                 subject, displayName, author) {
-        fire('notification', pub,
-          newNotification('group-subject', messageId, senderJID,
-                          { subject: subject }, displayName, author)
-        );
+        fire('notification', pub, newNotification(
+          'group-subject',
+          messageId,
+          senderJID,
+          { subject: subject },
+          timestamp,
+          displayName,
+          author
+        ));
         methods.call('notification_ack', [senderJID, messageId]);
       }
 
       function onGroupParticipantEvent(event, senderJID, jid, _,
                                        timestamp, messageId) {
-        fire('notification', pub,
-          newNotification('group-participant', messageId, senderJID,
-                          { event: event, participant: jid.split('@')[0] })
-        );
+        fire('notification', pub, newNotification(
+          'group-participant',
+          messageId,
+          senderJID,
+          { event: event, participant: jid.split('@')[0] },
+          timestamp
+        ));
         methods.call('notification_ack', [senderJID, messageId]);
       }
 
       function onGroupPictureEvent(event, senderJID, timestamp, messageId,
                                    pictureId, author) {
-        fire('notification', pub,
-          newNotification('group-picture', messageId, senderJID,
-                          { event: event, pictureId: pictureId }, null, author)
-        );
+        fire('notification', pub, newNotification(
+          'group-picture',
+          messageId,
+          senderJID,
+          { event: event, pictureId: pictureId },
+          timestamp,
+          null,
+          author
+        ));
         methods.call('notification_ack', [senderJID, messageId]);
       }
 
-      function newNotification(type, messageId, senderJID,
-                               content, displayName, author) {
+      function newNotification(type, messageId, senderJID, content,
+                               timestamp, displayName, author) {
+        // we get a unix timestamp without milliseconds, so we have
+        // to multiply with 1000
+        var sentDate = new Date(timestamp * 1000);
         return {
           messageId: messageId,
           sender: {
@@ -276,6 +292,7 @@
             authorMsisdn: !author ? undefined : author.split('@')[0]
           },
           content: content,
+          sentDate: sentDate,
           type: type
         };
       }
@@ -366,42 +383,56 @@
       function onMessageReceived(messageId, senderJID, content,
                                  timestamp, wantsReceipt, senderName,
                                  isBroadcast, authorJID) {
-        fire('message', pub,
-             newTextMessage(messageId, senderJID, content,
-                            senderName, authorJID));
+        fire('message', pub, newTextMessage(
+          messageId,
+          senderJID,
+          content,
+          timestamp,
+          senderName,
+          authorJID
+        ));
         methods.call('message_ack', [senderJID, messageId]);
         // TODO: The pub should be the client, we need to refactor this
         // module in order to provide the `singleton` module in a smarter way.
       }
 
       function onAudioReceived(messageId, senderJID, url, size,
-                               receiptRequested, isBroadcast) {
+                               receiptRequested, isBroadcast,
+                               pushName, timestamp) {
 
         onMultiMediaReceived('audio', messageId, senderJID, undefined, url,
-                             size, receiptRequested, isBroadcast);
+                             size, receiptRequested, isBroadcast,
+                             pushName, timestamp);
       }
 
       function onGroupAudioReceived(messageId, groupJID, authorJID, url, size,
-                                    receiptRequested) {
+                                    receiptRequested, pushName, timestamp) {
 
         onMultiMediaReceived('audio', messageId, groupJID, undefined, url,
-                             size, receiptRequested, false, authorJID);
+                             size, receiptRequested, false,
+                             authorJID, timestamp);
       }
 
       function onGroupMultiMediaReceived(type, messageId, groupJID, authorJID,
                                          preview, url, size, receiptRequested,
-                                         isBroadcast) {
+                                         pushName, timestamp) {
 
         onMultiMediaReceived(type, messageId, groupJID, preview, url, size,
-                             receiptRequested, false, authorJID);
+                             receiptRequested, false, authorJID, timestamp);
       }
 
       function onMultiMediaReceived(type, messageId, senderJID, preview, url,
                                     size, receiptRequested, isBroadcast,
-                                    authorJID) {
-        fire('message', pub,
-             newMultiMediaMessage(type, messageId, senderJID,
-                                  url, preview, authorJID));
+                                    pushName, timestamp) {
+        fire('message', pub, newMultiMediaMessage(
+          type,
+          messageId,
+          senderJID,
+          url,
+          preview,
+          pushName,
+          timestamp
+        ));
 
         methods.call('message_ack', [senderJID, messageId]);
         // TODO: The pub should be the client, we need to refactor this
@@ -410,7 +441,8 @@
 
       function onLocationReceived(messageId, senderJID, name, preview,
                                   latitude, longitude,
-                                  wantsReceipt, isBroadcast) {
+                                  wantsReceipt, isBroadcast, pushName,
+                                  timestamp) {
 
         fire('message', pub,
              newLocationMessage(messageId, senderJID,
@@ -421,7 +453,7 @@
 
       function onGroupLocationReceived(messageId, groupJID, authorJID, name,
                                        mediaPreview, mlatitude, mlongitude,
-                                       wantsReceipt) {
+                                       wantsReceipt, pushName, timestamp) {
         fire('message', pub,
              newLocationMessage(messageId, groupJID, name, mlatitude,
                                 mlongitude, authorJID));
@@ -468,8 +500,11 @@
         };
       }
 
-      function newTextMessage(messageId, senderJID, content, senderName,
-                              authorJID) {
+      function newTextMessage(messageId, senderJID, content,
+                              timestamp, senderName, authorJID) {
+        // we get a unix timestamp without milliseconds, so we have
+        // to multiply with 1000
+        var sentDate = new Date(timestamp * 1000);
         return {
           messageId: messageId,
           sender: {
@@ -478,12 +513,17 @@
             authorMsisdn: !authorJID ? undefined : authorJID.split('@')[0]
           },
           content: content,
+          sentDate: sentDate,
           type: 'text'
         };
       }
 
       function newMultiMediaMessage(type, messageId, senderJID,
-                                    url, binaryData, authorJID) {
+                                    url, binaryData, authorJID,
+                                    timestamp) {
+        // we get a unix timestamp without milliseconds, so we have
+        // to multiply with 1000
+        var sentDate = new Date(timestamp * 1000);
         return {
           messageId: messageId,
           sender: {
@@ -498,6 +538,7 @@
                       'data:image/jpeg;base64,' + binaryData :
                       getPlaceholder(type)
           },
+          sentDate: sentDate,
           type: type
         };
       }

--- a/app/scripts/vendor/coseme-client/client.js
+++ b/app/scripts/vendor/coseme-client/client.js
@@ -246,9 +246,9 @@
           messageId,
           senderJID,
           { subject: subject },
-          timestamp,
           displayName,
-          author
+          author,
+          timestamp
         ));
         methods.call('notification_ack', [senderJID, messageId]);
       }
@@ -260,6 +260,8 @@
           messageId,
           senderJID,
           { event: event, participant: jid.split('@')[0] },
+          null,
+          null,
           timestamp
         ));
         methods.call('notification_ack', [senderJID, messageId]);
@@ -272,15 +274,15 @@
           messageId,
           senderJID,
           { event: event, pictureId: pictureId },
-          timestamp,
           null,
-          author
+          author,
+          timestamp
         ));
         methods.call('notification_ack', [senderJID, messageId]);
       }
 
       function newNotification(type, messageId, senderJID, content,
-                               timestamp, displayName, author) {
+                               displayName, author, timestamp) {
         // we get a unix timestamp without milliseconds, so we have
         // to multiply with 1000
         var sentDate = new Date(timestamp * 1000);
@@ -387,9 +389,9 @@
           messageId,
           senderJID,
           content,
-          timestamp,
           senderName,
-          authorJID
+          authorJID,
+          timestamp
         ));
         methods.call('message_ack', [senderJID, messageId]);
         // TODO: The pub should be the client, we need to refactor this
@@ -501,7 +503,7 @@
       }
 
       function newTextMessage(messageId, senderJID, content,
-                              timestamp, senderName, authorJID) {
+                              senderName, authorJID, timestamp) {
         // we get a unix timestamp without milliseconds, so we have
         // to multiply with 1000
         var sentDate = new Date(timestamp * 1000);

--- a/app/scripts/views/compose-message.js
+++ b/app/scripts/views/compose-message.js
@@ -66,7 +66,10 @@ define([
         type: 'text',
         contents: text,
         from: {msisdn: global.auth.get('msisdn')},
-        meta: {date: new Date()}
+        meta: {
+          date: new Date(),
+          sentDate: new Date()
+        }
       });
 
       this.$messageComposer.html('<br>');

--- a/app/scripts/views/conversation.js
+++ b/app/scripts/views/conversation.js
@@ -496,7 +496,7 @@ define([
       // Make sure the view is added in the right position
       var found = this._findNextMessageIndex(message);
       if (!message.fromRemote && isNotFirstChunk) {
-        var messageTimestamp = message.get('meta').date.getTime();
+        var messageTimestamp = message.get('meta').sentDate.getTime();
         // This is because the message can come in any order so we force
         // elements after _nextToShow to be visible. Not optimal but working
         // as this happens only from time to time, mainly after resending

--- a/app/scripts/views/location-message.js
+++ b/app/scripts/views/location-message.js
@@ -30,7 +30,7 @@ define([
         locationText: this.model.get('contents').address ?
                       this.model.get('contents').address : ''
       });
-      data.meta.timestamp = data.meta.date.getTime();
+      data.meta.timestamp = data.meta.sentDate.getTime();
       var newElement = this.template(data);
       this.setElement(newElement);
 

--- a/app/scripts/views/multimedia-message.js
+++ b/app/scripts/views/multimedia-message.js
@@ -39,7 +39,7 @@ define([
       else {
         jsonModel.author = jsonModel.from.displayName;
       }
-      jsonModel.meta.timestamp = jsonModel.meta.date.getTime();
+      jsonModel.meta.timestamp = jsonModel.meta.sentDate.getTime();
       var newElement = this.template(jsonModel);
       this.setElement(newElement);
     },

--- a/app/scripts/views/text-message.js
+++ b/app/scripts/views/text-message.js
@@ -29,7 +29,7 @@ define([
 
     render: function () {
       var jsonModel = this.model.toJSON();
-      jsonModel.meta.timestamp = jsonModel.meta.date.getTime();
+      jsonModel.meta.timestamp = jsonModel.meta.sentDate.getTime();
       if (jsonModel.from.authorMsisdn) {
         jsonModel.author =
           global.contacts.getParticipantName(jsonModel.from.authorMsisdn);


### PR DESCRIPTION
Until now, OpenWapp displays and sorts by the date/time when messages are received. This usually unpractical if you are not always connected to the internet.

This issue was reported in #72, which this PR addresses. Instead of using the receiving date/time the sent date/time transmitted from WhatsApp will be used.

This PR depends on mozillahispano/coseme#34 and I would be happy if you could merge them both. I have tested this patch with text, image, video and audio messages. I have not tested location messages.
I'd be happy if this could be tested, once again, before merging.
